### PR TITLE
Trying to remove redirect to robo.sntiitk.in

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-robo.sntiitk.in


### PR DESCRIPTION
The redirect works by adding the custom domain to the 'CNAME' file. The file is removed in this commit. This may prevent the redirect.
The website in this repository is working correctly.